### PR TITLE
Force HTTP/1.1 for Cloudinary uploads (CORE-3860)

### DIFF
--- a/lib/cloudex/cloudinary_api.ex
+++ b/lib/cloudex/cloudinary_api.ex
@@ -118,7 +118,10 @@ defmodule Cloudex.CloudinaryApi do
       hackney: [
         basic_auth: {Cloudex.Settings.get(:api_key), Cloudex.Settings.get(:secret)},
         timeout: 60_000,
-        recv_timeout: 60_000
+        recv_timeout: 60_000,
+        # hackney 4.x auto-negotiates HTTP/2 via ALPN; its h2 stack mishandles large
+        # multipart bodies over pooled connections, dropping the file part (CORE-3860).
+        protocols: [:http1]
       ]
     ]
   end


### PR DESCRIPTION
## Summary
- hackney 4.x auto-negotiates HTTP/2 via ALPN; its h2 stack mishandles large multipart bodies over pooled connections, silently dropping the file part
- Cloudinary uploads (1-2.4MB PNGs) fail 100% in prod with "Missing required parameter - file" since the hackney 1.x → 4.x bump
- Add `protocols: [:http1]` to `credentials/0` hackney opts, mirroring the ExAws fix from IE-129

## Test plan
- [ ] Bump `walnut_monorepo` api's cloudex ref to this branch's HEAD and confirm AI image generation succeeds against a real Cloudinary account

Fixes teamwalnut/walnut_monorepo CORE-3860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JChrbXt43Khg8ByVUCHupd