### PR TITLE
CORE-3860: isolate Cloudinary uploads to a dedicated hackney pool

### DIFF
--- a/lib/cloudex/cloudinary_api.ex
+++ b/lib/cloudex/cloudinary_api.ex
@@ -124,7 +124,15 @@ defmodule Cloudex.CloudinaryApi do
         # multipart file upload arrives with no `file` part, so Cloudinary rejects
         # it with "Missing required parameter - file". Mirrors the ExAws HTTP/1.1
         # workaround (walnut IE-129 / CORE-3775).
-        protocols: [:http1]
+        protocols: [:http1],
+        # Dedicated pool, isolated from the app-wide `:default` hackney pool
+        # every other outgoing HTTP call shares. CORE-3860's http1 override
+        # still left one intermittent "Missing required parameter - file"
+        # failure days after deploy; giving Cloudinary uploads their own pool
+        # rules out any interaction with unrelated traffic on the shared pool
+        # (load_regulation slot contention, TCP connections churned by other
+        # hosts, etc.) as a contributing factor.
+        pool: :cloudinary_uploads
       ]
     ]
   end


### PR DESCRIPTION
## Summary
- CORE-3860's http1 override cut Cloudinary upload failures 100% -> ~1 in 3 days, but didn't eliminate them ("Missing required parameter - file" still recurs occasionally).
- Reading hackney 4.4.5's pool code, couldn't confirm a stale-h2-connection-reuse mechanism (ssl_pooling is off app-wide, so ALPN renegotiates fresh per request) — root cause of the residual failure is unconfirmed.
- Defense-in-depth: give Cloudinary uploads their own named hackney pool (`:cloudinary_uploads`), isolated from the app-wide `:default` pool shared by every other outgoing HTTP call in walnut_monorepo.

## Test plan
- [ ] `mix test` in this repo
- [ ] Bump ref in walnut_monorepo's api/mix.exs + mix.lock, verify `mix compile` succeeds
- [ ] Monitor Datadog for further "Missing required parameter - file" occurrences post-deploy

https://claude.ai/code/session_01NMpfD6rwyA3KGcsbSoEczQ